### PR TITLE
Update/Init Submodule as part of Gradle build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.* text=auto eol=lf

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 <!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
 <!--- as this will allow Github to automatically close the related Issue -->
 
-## Implementaion
+## Implementation
 <!--- Explain what was done to address the problem/need -->
 <!--- Also mention any known or possible side effects -->
 

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,31 @@ gversion {
 //}
 //compileJava.finalizedBy checkAkitInstall
 
+task unpackSaddlebags(type: Exec) {
+    // Possible paths to Git installation
+    // List Linux paths first
+    def gitPaths = [
+        '/usr/bin/git',
+        '/bin/git',
+        'C:/Program Files/Git/bin/git.exe',
+        'C:/Program Files(x86)/Git/bin/git.exe'
+    ]
+    // Set first existing path as the program to execute
+    for (g in gitPaths) {
+        if (file(g).exists()) {
+            executable g
+            break
+        }
+    }
+    // If saddlebags submodule is initialized already, just run update
+    // else initialize the submodule
+    if (file('src/saddlebags/README.md').exists())
+        args 'submodule', 'update'
+    else
+        args 'submodule', 'update', '--init'
+}
+
+
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.
 dependencies {
@@ -206,6 +231,7 @@ test {
     useJUnitPlatform()
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
 }
+compileJava.dependsOn("unpackSaddlebags")
 compileJava.finalizedBy("spotlessApply")
 
 sourceSets {


### PR DESCRIPTION
Add gradle task to initialize/update saddlebags
Also copy in line endings git config from crescendo

## Justification
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
VSCode Git Extension doesn't include submodule commands, so students would need to run a terminal git command to initialize the submodule after cloning. Need a more automatic method of initializing and updating the saddlebags submodule.

## Implementation
<!--- Explain what was done to address the problem/need -->
<!--- Also mention any known or possible side effects -->
Made a gradle task called 'unpackSaddlebags' that runs `git submodule update --init` or `git submodule update` depending on whether or not the submodule has been initialized already. Made this task a dependency for the compileJava task

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested behavior when build was run when the submodule is in different states:
- Uninitialized -> Build initializes the saddlebags submodule
- Initialized on a different commit than main repo is tracking (Unstaged) -> saddlebags is reset to the main repo commit
- Initialized on a different commit than main repo is tracking (Staged) -> saddlebags is not modified
