### PR TITLE
Motion magic elevator sim

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -1,12 +1,21 @@
 package frc.robot;
 
+import static edu.wpi.first.units.Units.Hertz;
 import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.InchesPerSecond;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Pounds;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Second;
 
 import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.units.AngularAccelerationUnit;
+import edu.wpi.first.units.measure.AngularAcceleration;
+import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Mass;
+import edu.wpi.first.units.measure.Velocity;
+import frc.robot.subsystems.Elevator;
 
 public final class Constants {
 
@@ -44,7 +53,6 @@ public final class Constants {
     public static final double I = 0.04;
     public static final double D = 0.02;
     public static final double FF = 0.0;
-    public static final double MMVel = 30;
     public static final Distance kBottomLimit = Inches.of(9);
     public static final Distance kTopLimit = Inches.of(75);
     public static final double kElevatorConversion = 1.0;
@@ -59,8 +67,12 @@ public final class Constants {
     public static final Mass kCarriageMass = Pounds.of(5.15);
     public static final Distance kElevatorDrumRadius = Inches.of(.75 / 2);
     public static final Distance kMinElevatorHeight = Inches.zero();
-    public static final Distance kMaxElevatorHeight = Inches.of(72);
+    public static final Distance kMaxElevatorHeight = Inches.of(80);
     public static final Distance kElevatorDrumCircumference =
         kElevatorDrumRadius.times(2 * Math.PI);
+    public static final AngularVelocity MMVel = Elevator.heightToRotations(InchesPerSecond.of(60));
+    public static final AngularAcceleration MMAcc = MMVel.times(Hertz.of(5));
+    public static final Velocity<AngularAccelerationUnit> MMJerk =
+        RotationsPerSecondPerSecond.per(Second).of(MMAcc.in(RotationsPerSecondPerSecond)).times(10);
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -67,7 +67,7 @@ public final class Constants {
     public static final Mass kCarriageMass = Pounds.of(5.15);
     public static final Distance kElevatorDrumRadius = Inches.of(.75 / 2);
     public static final Distance kMinElevatorHeight = Inches.zero();
-    public static final Distance kMaxElevatorHeight = Inches.of(80);
+    public static final Distance kMaxElevatorHeight = Inches.of(72);
     public static final Distance kElevatorDrumCircumference =
         kElevatorDrumRadius.times(2 * Math.PI);
     public static final AngularVelocity MMVel = Elevator.heightToRotations(InchesPerSecond.of(60));


### PR DESCRIPTION
## Justification
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
We had been having trouble simulated using TalonFXSimState. However, these changes got it to inexplicably work nicely in simulation. 

Since almost all changes we had already tried at one point or another, I didn't feel it was necessary to make a student redo this work. 

## Implementation
<!--- Explain what was done to address the problem/need -->
<!--- Also mention any known or possible side effects -->
Added a TalonFXSimState instance and assigned voltage, position, and velocity in simulationPeriodic() based off of the ElevatorSim outputs. 

The two other important changes: 
- Motion magic Units (Angular Jerk is particularly painful unit to use in the Java Units library)
- Setting the ChassisReference Orientation in the TalonFXSimState. This was one of the issues preventing the simulation from behaving as we expected. 

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Works in sim. Motion Magic is quite smooth.