### PR TITLE
Test Mode Mappings

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -166,6 +166,14 @@ public class Robot extends LoggedRobot {
   public void testInit() {
     // Cancels all running commands at the start of test mode.
     CommandScheduler.getInstance().cancelAll();
+    CommandScheduler.getInstance().setActiveButtonLoop(robotContainer.getTestEventLoop());
+  }
+
+  @Override
+  public void testExit() {
+    CommandScheduler.getInstance().cancelAll();
+    CommandScheduler.getInstance()
+        .setActiveButtonLoop(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
   /** This function is called periodically during test mode. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -159,7 +159,7 @@ public class RobotContainer {
   }
 
   private void configureTestButtonBindsing() {
-    testTrig(OI.getTrigger(usingKeyboard ? OI.Keyboard.Period : OI.Driver.DPAD_UP))
+    testTrig(usingKeyboard ? OI.getButton(OI.Keyboard.Period) : OI.getPOVButton(OI.Driver.DPAD_UP))
         .whileTrue(elevator.goUp(() -> 1.0));
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -23,9 +23,11 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.commands.DriveCommands;
 import frc.robot.generated.TunerConstants;
@@ -46,6 +48,12 @@ import org.littletonrobotics.junction.networktables.LoggedDashboardChooser;
  */
 @SuppressWarnings("unused")
 public class RobotContainer {
+
+  private EventLoop testEventLoop = new EventLoop();
+
+  // Change the raw boolean to true to pick keyboard during simulation
+  private final boolean usingKeyboard = true && Robot.isSimulation();
+
   // Subsystems
   private final Drive drive;
   private final Vision vision;
@@ -139,22 +147,29 @@ public class RobotContainer {
 
     // Configure the button bindings
     configureButtonBindings();
+    configureTestButtonBindsing();
+  }
+
+  public EventLoop getTestEventLoop() {
+    return testEventLoop;
+  }
+
+  private Trigger testTrig(Trigger t) {
+    return new Trigger(testEventLoop, () -> t.getAsBoolean());
+  }
+
+  private void configureTestButtonBindsing() {
+    testTrig(OI.getTrigger(usingKeyboard ? OI.Keyboard.Period : OI.Driver.DPAD_UP))
+        .whileTrue(elevator.goUp(() -> 1.0));
   }
 
   private void configureButtonBindings() {
-    // Change the raw boolean to true to pick keyboard durring simulation
-    boolean usingKeyboard = true && Robot.isSimulation();
 
     OI.getButton(usingKeyboard ? OI.Keyboard.Z : OI.Driver.X).onTrue(elevator.L0());
     OI.getButton(usingKeyboard ? OI.Keyboard.M : OI.Driver.Back).onTrue(elevator.L1());
     OI.getButton(usingKeyboard ? OI.Keyboard.X : OI.Driver.A).onTrue(elevator.L2());
     OI.getButton(usingKeyboard ? OI.Keyboard.C : OI.Driver.B).onTrue(elevator.L3());
     OI.getButton(usingKeyboard ? OI.Keyboard.V : OI.Driver.Y).onTrue(elevator.L4());
-    OI.getButton(usingKeyboard ? OI.Keyboard.Period : OI.Driver.DPAD_UP)
-        .whileTrue(
-            usingKeyboard
-                ? elevator.goUp(() -> 1.0)
-                : elevator.goUp(OI.getAxisSupplier(OI.Driver.RightY)));
     OI.getButton(usingKeyboard ? OI.Keyboard.Comma : OI.Driver.DPAD_DOWN)
         .whileTrue(
             usingKeyboard

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -155,7 +155,7 @@ public class RobotContainer {
   }
 
   private Trigger testTrig(Trigger t) {
-    return new Trigger(testEventLoop, () -> t.getAsBoolean());
+    return new Trigger(testEventLoop, t);
   }
 
   private void configureTestButtonBindsing() {


### PR DESCRIPTION
## Justification
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
We have a lot of temporary button mapping for bring up/debug testing that we want to have available outside the context of normal operation. 

Setting up button mappings for Test Mode only seems like a nice way to achieve this. 

## Implementation
<!--- Explain what was done to address the problem/need -->
<!--- Also mention any known or possible side effects -->
Created a new EventLoop in RobotContainer and a method to add Triggers to that EventLoop. 
Then switch to that EventLoop when testInit() is called, and back to the default EventLoop when testExit() is called. 

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
~None yet. Students should verify this approach before using it in their subsystems!~ 
Tested in simulation