### PR TITLE
encoder checking

### DIFF
--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -202,10 +202,10 @@ public class IntakeSubsystem extends SubsystemBase {
   }
 
   public void seedEncoder() {
-    if(throughBoreEncoder.get() < 0.5) {
+    if (throughBoreEncoder.get() < 0.5) {
       pivotMotor.setPosition(throughBoreEncoder.get());
-    } else{
-    pivotMotor.setPosition(throughBoreEncoder.get() - 1);
+    } else {
+      pivotMotor.setPosition(throughBoreEncoder.get() - 1);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -202,7 +202,11 @@ public class IntakeSubsystem extends SubsystemBase {
   }
 
   public void seedEncoder() {
-    pivotMotor.setPosition(throughBoreEncoder.get());
+    if(throughBoreEncoder.get() < 0.5) {
+      pivotMotor.setPosition(throughBoreEncoder.get());
+    } else{
+    pivotMotor.setPosition(throughBoreEncoder.get() - 1);
+    }
   }
 
   public Angle getPivotPosition() {


### PR DESCRIPTION
Justification
Absolute encoder doesn't seed properly if it's extended, due to it being in rotations.

Implementation
Check if encoder is beyond 1/2 a rotation, if no, then seed encoder to encoder.get(), othwerwise seed encoder to encoder.get() - 1

Testing Done
None

